### PR TITLE
switched active storage to amazon in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,9 +41,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
-
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
   # config.action_cable.url = "wss://example.com/cable"


### PR DESCRIPTION
- Active storage config was set to local in config/environments/production.rb
- This hotfix should solve that problem by removing that line and ensuring that the active storage service is set to amazon.